### PR TITLE
Adds browserify support to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
   ],
   "author": "RReverser <me@rreverser.com> (http://rreverser.com/)",
   "files": [
-    "dist/node/jbinary.js"
+    "dist/node/jbinary.js",
+    "dist/browser/jbinary.js"
   ],
   "main": "dist/node/jbinary.js",
+  "browser": "dist/browser/jbinary.js",
   "scripts": {
     "test": "grunt"
   },


### PR DESCRIPTION
This PR is in response to #42.  Adding the `browser` field to package.json enables browserify to pick up the dist/browser/jbinary.js file instead of the normal node/jbinary.js file.  No effect on node usage.