### PR TITLE
Guard against for stream.read returning null in nodejs

### DIFF
--- a/src/io/load.js
+++ b/src/io/load.js
@@ -28,8 +28,15 @@ jBinary.loadData = promising(function (source, callback) {
 	if (NODE && is(source, ReadableStream)) {
 		var buffers = [];
 		source
-			.on('readable', function () { buffers.push(this.read()) })
-			.on('end', function () { callback(null, Buffer.concat(buffers)) })
+			.on('readable', function () {
+				var buf = this.read();
+				if(buf) {
+					buffers.push(buf);
+				}
+			})
+			.on('end', function () {
+				callback(null, Buffer.concat(buffers));
+			})
 			.on('error', callback)
 		;
 	} else

--- a/test/test.js
+++ b/test/test.js
@@ -204,6 +204,17 @@ suite('Loading data', function () {
 		});
 	}
 
+	if (hasNodeRequire && require('stream').Readable) {
+		test('from file-based readableStream', function (done) {
+			var stream = require('fs').createReadStream(localFileName);
+			jBinary.loadData(stream, function (err, data) {
+				assert.notOk(err, err);
+				assert.equal(data.byteLength || data.length, 512);
+				done();
+			});
+		});
+	}
+
 	test('with explicit typeset object', function (done) {
 		var typeSet = {
 			IS_CORRECT_TYPESET: true


### PR DESCRIPTION
Suggested fix to guard against stream.read() returning a null value in nodejs 0.12.34  (re: issue#46)

I have added an extra test. I ran grunt using both nodejs 0.10.x and 0.12.34, and the test passes in both instances. I'm not familiar enough with grunt&mocha to be able to work out why the test passes in 0.10.x. I verified that the additional check solves the problem I was experiencing & it shouldn't have any unwanted side-effect.